### PR TITLE
Add docs for StringToDoubleConverter and StringToIntConverter

### DIFF
--- a/docs/TOC.yml
+++ b/docs/TOC.yml
@@ -50,6 +50,10 @@
       href: converters/multiconverter.md
     - name: NotEqualConverter
       href: converters/notequalconverter.md
+    - name: StringToDoubleConverter
+      href: converters/stringtodoubleconverter.md
+    - name: StringToIntConverter
+      href: converters/stringtointconverter.md
     - name: TextCaseConverter
       href: converters/textcaseconverter.md
 - name: "Effects"

--- a/docs/converters/stringtodoubleconverter.md
+++ b/docs/converters/stringtodoubleconverter.md
@@ -1,0 +1,47 @@
+---
+title: "Xamarin Community Toolkit StringToDoubleConverter"
+author: sthewissen
+ms.author: joverslu
+description: "The StringToDoubleConverter allows users to convert an incoming string value to a double."
+ms.date: 10/31/2020
+---
+
+# Xamarin Community Toolkit StringToDoubleConverter
+
+The StringToDoubleConverter is a converter that allows users to convert an incoming `string` value to a `double`.
+
+## Syntax
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:xct="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
+             x:Class="MyLittleApp.MainPage">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <xct:StringToDoubleConverter x:Key="StringToDoubleConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <StackLayout>
+
+        <Label Text="{Binding MyString, Converter={StaticResource StringToDoubleConverter}}" />
+
+    </StackLayout>
+</ContentPage>
+```
+
+## Sample
+
+> [!NOTE]
+> Currently there's no sample available for this feature yet. Want to add one? We are open to [community contributions](https://github.com/xamarin/XamarinCommunityToolkit).
+
+<!-- [StringToDoubleConverter sample page Source](https://github.com/xamarin/XamarinCommunityToolkit)
+
+You can see this in action in the [Xamarin Community Toolkit Sample App](https://github.com/xamarin/XamarinCommunityToolkit). -->
+
+## API
+
+* [StringToDoubleConverter source code](https://github.com/xamarin/XamarinCommunityToolkit/blob/main/XamarinCommunityToolkit/Converters/StringToDoubleConverter.shared.cs)

--- a/docs/converters/stringtointconverter.md
+++ b/docs/converters/stringtointconverter.md
@@ -1,0 +1,47 @@
+---
+title: "Xamarin Community Toolkit StringToIntConverter"
+author: sthewissen
+ms.author: joverslu
+description: "The StringToIntConverter allows users to convert an incoming string value to an int."
+ms.date: 10/31/2020
+---
+
+# Xamarin Community Toolkit StringToIntConverter
+
+The StringToIntConverter is a converter that allows users to convert an incoming `string` value to an `int`.
+
+## Syntax
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:xct="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
+             x:Class="MyLittleApp.MainPage">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <xct:StringToIntConverter x:Key="StringToIntConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <StackLayout>
+
+        <Label Text="{Binding MyString, Converter={StaticResource StringToIntConverter}}" />
+
+    </StackLayout>
+</ContentPage>
+```
+
+## Sample
+
+> [!NOTE]
+> Currently there's no sample available for this feature yet. Want to add one? We are open to [community contributions](https://github.com/xamarin/XamarinCommunityToolkit).
+
+<!-- [StringToIntConverter sample page Source](https://github.com/xamarin/XamarinCommunityToolkit)
+
+You can see this in action in the [Xamarin Community Toolkit Sample App](https://github.com/xamarin/XamarinCommunityToolkit). -->
+
+## API
+
+* [StringToIntConverter source code](https://github.com/xamarin/XamarinCommunityToolkit/blob/main/XamarinCommunityToolkit/Converters/StringToIntConverter.shared.cs)


### PR DESCRIPTION
## Fixes 
- Fixes #22

## Docs for Toolkit PR [#447](https://github.com/xamarin/XamarinCommunityToolkit/pulls/#447) <!-- Link to relevant issue or Feature PR # of the Xamarin community toolkit repo which will create a reference to the associated issue and PR once it is created, remove if not tied to an issue or feature -->

## What changes to the docs does this PR provide?
Adds documentation for:

- `StringToDoubleConverter`
- `StringToIntConverter`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] For new pages, used the [provided template](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/.template.md).
- [X] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/toc.yml).
- [X] Ran against a spell and grammar checker.
- [X] Contains **NO** breaking changes.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->