### PR TITLE
Add note to Expander to not use it in ListView or CollectionView

### DIFF
--- a/docs/views/expander.md
+++ b/docs/views/expander.md
@@ -11,6 +11,9 @@ ms.author: joverslu
 
 The Xamarin.CommunityToolkit `Expander` control provides an expandable container to host any content. The control has a header and content, and the content is shown or hidden by tapping the `Expander` header. When only the `Expander` header is shown, the `Expander` is *collapsed*. When the `Expander` content is visible the `Expander` is *expanded*.
 
+> [!NOTE]
+> The `Expander` control is known to show unwanted behavior when used in a `ListView` or `CollectionView`. At this time we recommend not using a `Expander` in one of these controls.
+
 The following screenshots show an `Expander` in its collapsed and expanded states, with red boxes indicating the header and the content:
 
 ![Screenshot of an Expander in collapsed and expanded states, on iOS and Android](expander-images/expander.png "Expander on iOS and Android")


### PR DESCRIPTION
## Fixes NA

## What changes to the docs does this PR provide?

There are known issues when using the `Expander` inside of a `ListView` or `CollectionView` this adds a note to warn people for that.

<!-- Please describe the updated information in detail -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/.template.md).
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/toc.yml).
- [x] Ran against a spell and grammar checker.
- [x] Contains **NO** breaking changes.
