### PR TITLE
Add XAML namespace in getting started

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -16,15 +16,15 @@ The toolkit is available as a NuGet package that can be added to any existing or
 
     ![NuGet Package](~/images/managenuget.png "Manage NuGet Package Image")
 
-3. To add the namespace to the toolkit
+3. To add the namespace to the toolkit:
 
-    * in your C# page, add:
+    * In your C# page, add:
 
         ```c#
         using Xamarin.CommunityToolkit;
         ```
         
-    * in your XAML page, add the namespace attribute:
+    * In your XAML page, add the namespace attribute:
     
         ```xaml
         xmlns:xct="http://xamarin.com/schemas/2020/toolkit"

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -16,12 +16,18 @@ The toolkit is available as a NuGet package that can be added to any existing or
 
     ![NuGet Package](~/images/managenuget.png "Manage NuGet Package Image")
 
-3. There's no need to reference the toolkit in your XAML pages as we're sharing the namespace definition with Xamarin.Forms.
+3. To add the namespace to the toolkit
 
-    * In your C# page, you can add the namespace to the toolkit:
+    * in your C# page, add:
 
         ```c#
         using Xamarin.CommunityToolkit;
+        ```
+        
+    * in your XAML page, add the namespace attribute:
+    
+        ```xaml
+        xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
         ```
 
 4. Check out the rest of the documentation to learn more about implementing specific features.


### PR DESCRIPTION
## What changes to the docs does this PR provide?

Currently the getting started guide incorrectly states that no namespace has to be specified in xaml files to use the community toolkit, while it does (already correctly documented in the main repo readme: https://github.com/xamarin/XamarinCommunityToolkit#getting-started).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~For new pages, used the [provided template](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/.template.md).~
- [ ] ~For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/toc.yml).~
- [ ] Ran against a spell and grammar checker.  
Only edited in githubs online editor, that probably doesn't have a checker - I am pretty confident in the few words used here though :)
- [ ] Contains **NO** breaking changes.  
What is a breaking doc change?
