### PR TITLE
Remove converter examples for deduplication

### DIFF
--- a/docs/behaviors/eventtocommandbehavior.md
+++ b/docs/behaviors/eventtocommandbehavior.md
@@ -27,26 +27,6 @@ When using this behavior with selection or tap events exposed by `ListView` an a
 - [ItemSelectedEventArgsConverter](~/converters/itemselectedeventargsconverter.md)
 - [ItemTappedEventArgsConverter](~/converters/itemtappedeventargsconverter.md)
 
-```xml
-<ListView.Behaviors>
-    <behaviors:EventToCommandBehavior
-        EventName="ItemSelected"
-        Command="{Binding ItemSelectedCommand}"
-        EventArgsConverter="{StaticResource ItemSelectedEventArgsConverter}"
-    />
-</ListView.Behaviors>
-```
-
-```xml
-<ListView.Behaviors>
-    <behaviors:EventToCommandBehavior
-        EventName="ItemTapped"
-        Command="{Binding ItemTappedCommand}"
-        EventArgsConverter="{StaticResource ItemTappedEventArgsConverter}"
-     />
-</ListView.Behaviors>
-```
-
 ## Properties
 
 |Property  |Type  |Description  |


### PR DESCRIPTION
The example use an uncommon prefix (not `xct`) and thus likely don't work when copy-pasting. And the resource is probably getting forgotten too. The same example exists with the correct prefix and the resource definition in the linked help articles. Thus I opted to remove the examples, thus guiding the user via the links to those articles with the complete examples.