### PR TITLE
DocuTune: Apply metadata properties for advocate contributors

### DIFF
--- a/docs/helpers/delegateweakeventmanager.md
+++ b/docs/helpers/delegateweakeventmanager.md
@@ -4,6 +4,8 @@ author: brminnick
 ms.author: bramin
 description: "A Delegate event implementation that enables the garbage collector to collect an object without needing to unsubscribe event handlers."
 ms.date: 11/20/2020
+ms.custom: team=cloud_advocates
+ms.contributors: bramin-03042021
 ---
 
 # Xamarin Community Toolkit DelegateWeakEventManager

--- a/docs/helpers/weakeventmanagerextensions.md
+++ b/docs/helpers/weakeventmanagerextensions.md
@@ -4,6 +4,8 @@ author: brminnick
 ms.author: bramin
 description: "Extension methods for Xamarin.Forms.WeakEventManager."
 ms.date: 11/20/2020
+ms.custom: team=cloud_advocates
+ms.contributors: bramin-01142021
 ---
 
 # Xamarin Community Toolkit WeakEventManagerExtensions

--- a/docs/helpers/weakeventmanagert.md
+++ b/docs/helpers/weakeventmanagert.md
@@ -4,6 +4,8 @@ author: brminnick
 ms.author: bramin
 description: "An event implementation that enables the garbage collector to collect an object without needing to unsubscribe event handlers."
 ms.date: 11/20/2020
+ms.custom: team=cloud_advocates
+ms.contributors: bramin-03042021
 ---
 
 # Xamarin Community Toolkit WeakEventManager<TEventArgs>

--- a/docs/objectmodel/asynccommand.md
+++ b/docs/objectmodel/asynccommand.md
@@ -4,6 +4,8 @@ author: brminnick
 ms.author: bramin
 description: "Enables the Task type to safely be used asynchronously with an ICommand."
 ms.date: 11/20/2020
+ms.custom: team=cloud_advocates
+ms.contributors: bramin-03042021
 ---
 
 # Xamarin Community Toolkit AsyncCommand

--- a/docs/objectmodel/asyncvaluecommand.md
+++ b/docs/objectmodel/asyncvaluecommand.md
@@ -4,6 +4,8 @@ author: brminnick
 ms.author: bramin
 description: "Enables the ValueTask type to safely be used asynchronously with an ICommand."
 ms.date: 11/20/2020
+ms.custom: team=cloud_advocates
+ms.contributors: bramin-03042021
 ---
 
 # Xamarin Community Toolkit AsyncValueCommand


### PR DESCRIPTION
DocuTune: Apply metadata properties for advocate contributors

Note the following:

- DocuTune drives improved quality of technical content by finding and automatically correcting a broad set of issues in Markdown and YAML files. DocuTune performs these updates intelligently, only making corrections in the sections of a document where the correction is suitable.
- DocuTune PRs often standardize spacing, formatting, and casing of Markdown elements to support the DocuTune onboarding process.
- DocuTune PRs might contain other minor edits noticed during a manual review.
- DocuTune PRs might include files whose Acrolinx score was below the target threshold prior to this PR.
- Delimiters such as asterisks and backticks may be added to link descriptions or alt-text to denote UI elements or other string literals that should not be modified during automation.
- Other formatting or indentation corrections might appear in DocuTune PRs to improve the accuracy of document parsing.

PointOfContact: @scottboc (Scott Bockheim)
CorrelationId: 70d29a1f-52c7-4693-b6b6-48364523765f
