### PR TITLE
[Fix] Media Element Docs's broken  preview image markdown links.

### DIFF
--- a/docs/views/mediaelement.md
+++ b/docs/views/mediaelement.md
@@ -8,7 +8,7 @@ ms.date: 10/21/2020
 
 # Xamarin Community Toolkit MediaElement
 
-[![Download Sample.](~/images/download.png) Download the sample](/samples/xamarin/xamarin-forms-samples/userinterface-mediaelementdemos/)
+[![Download Sample.](../images/download.png) Download the sample](/samples/xamarin/xamarin-forms-samples/userinterface-mediaelementdemos/)
 
 `MediaElement` is a view for playing video and audio. Media that's supported by the underlying platform can be played from the following sources:
 
@@ -19,7 +19,7 @@ ms.date: 10/21/2020
 
 `MediaElement` can use the platform playback controls, which are referred to as transport controls. However, they are disabled by default and can be replaced with your own transport controls. The following screenshots show `MediaElement` playing a video with the platform transport controls:
 
-[![Screenshot of a MediaElement playing a video, on iOS and Android.](mediaelement-images/playback-controls.png](mediaelement-images/playback-controls-large.png#lightbox)
+[![Screenshot of a MediaElement playing a video, on iOS and Android.](mediaelement-images/playback-controls-large.png#lightbox)
 
 > [!NOTE]
 > `MediaElement` is available on iOS, Android, the Universal Windows Platform (UWP), macOS, Windows Presentation Foundation, and Tizen.
@@ -279,7 +279,7 @@ The property change notification for the `Position` bindable property fire at 20
 
 In this example, the `Maximum` property of the `Slider` is data-bound to the `Duration` property of the `MediaElement` and the [`Value`](xref:Xamarin.Forms.Slider.Value) property of the [`Slider`](xref:Xamarin.Forms.Slider) is data-bound to the `Position` property of the `MediaElement`. Therefore, dragging the `Slider` results in the media playback position changing:
 
-[![Screenshot of a MediaElement with a position bar, on iOS and Android.](mediaelement-images/custom-position-bar.png](mediaelement-images/custom-position-bar-large.png#lightbox)
+[![Screenshot of a MediaElement with a position bar, on iOS and Android.](mediaelement-images/custom-position-bar-large.png#lightbox)
 
 In addition, a [`DataTrigger`](xref:Xamarin.Forms.DataTrigger) object is used to disable the `Slider` when the media is buffering. For more information about data triggers, see [Xamarin.Forms Triggers](/xamarin/xamarin-forms/app-fundamentals/triggers).
 
@@ -402,11 +402,11 @@ void OnStopButtonClicked(object sender, EventArgs args)
 
 The **Play** button can be pressed, once it becomes enabled, to begin playback:
 
-[![Screenshot of a MediaElement with custom transport controls, on iOS and Android.](mediaelement-images/custom-transport-playback.png](mediaelement-images/custom-transport-playback-large.png#lightbox)
+[![Screenshot of a MediaElement with custom transport controls, on iOS and Android.](mediaelement-images/custom-transport-playback-large.png#lightbox)
 
 Pressing the **Pause** button results in playback pausing:
 
-[![Screenshot of a MediaElement with playback paused, on iOS and Android.](mediaelement-images/custom-transport-paused.png](mediaelement-images/custom-transport-paused-large.png#lightbox)
+[![Screenshot of a MediaElement with playback paused, on iOS and Android.](mediaelement-images/custom-transport-paused-large.png#lightbox)
 
 Pressing the **Stop** button stops playback and returns the position of the media file to the beginning.
 

--- a/docs/views/mediaelement.md
+++ b/docs/views/mediaelement.md
@@ -8,7 +8,7 @@ ms.date: 10/21/2020
 
 # Xamarin Community Toolkit MediaElement
 
-[![Download Sample.](../images/download.png) Download the sample](/samples/xamarin/xamarin-forms-samples/userinterface-mediaelementdemos/)
+[![Download Sample.](~/images/download.png) Download the sample](/samples/xamarin/xamarin-forms-samples/userinterface-mediaelementdemos/)
 
 `MediaElement` is a view for playing video and audio. Media that's supported by the underlying platform can be played from the following sources:
 

--- a/docs/views/mediaelement.md
+++ b/docs/views/mediaelement.md
@@ -19,7 +19,7 @@ ms.date: 10/21/2020
 
 `MediaElement` can use the platform playback controls, which are referred to as transport controls. However, they are disabled by default and can be replaced with your own transport controls. The following screenshots show `MediaElement` playing a video with the platform transport controls:
 
-[![Screenshot of a MediaElement playing a video, on iOS and Android.](mediaelement-images/playback-controls-large.png#lightbox)
+![Screenshot of a MediaElement playing a video, on iOS and Android.](mediaelement-images/playback-controls-large.png#lightbox)
 
 > [!NOTE]
 > `MediaElement` is available on iOS, Android, the Universal Windows Platform (UWP), macOS, Windows Presentation Foundation, and Tizen.
@@ -279,7 +279,7 @@ The property change notification for the `Position` bindable property fire at 20
 
 In this example, the `Maximum` property of the `Slider` is data-bound to the `Duration` property of the `MediaElement` and the [`Value`](xref:Xamarin.Forms.Slider.Value) property of the [`Slider`](xref:Xamarin.Forms.Slider) is data-bound to the `Position` property of the `MediaElement`. Therefore, dragging the `Slider` results in the media playback position changing:
 
-[![Screenshot of a MediaElement with a position bar, on iOS and Android.](mediaelement-images/custom-position-bar-large.png#lightbox)
+![Screenshot of a MediaElement with a position bar, on iOS and Android.](mediaelement-images/custom-position-bar-large.png#lightbox)
 
 In addition, a [`DataTrigger`](xref:Xamarin.Forms.DataTrigger) object is used to disable the `Slider` when the media is buffering. For more information about data triggers, see [Xamarin.Forms Triggers](/xamarin/xamarin-forms/app-fundamentals/triggers).
 
@@ -402,11 +402,11 @@ void OnStopButtonClicked(object sender, EventArgs args)
 
 The **Play** button can be pressed, once it becomes enabled, to begin playback:
 
-[![Screenshot of a MediaElement with custom transport controls, on iOS and Android.](mediaelement-images/custom-transport-playback-large.png#lightbox)
+![Screenshot of a MediaElement with custom transport controls, on iOS and Android.](mediaelement-images/custom-transport-playback-large.png#lightbox)
 
 Pressing the **Pause** button results in playback pausing:
 
-[![Screenshot of a MediaElement with playback paused, on iOS and Android.](mediaelement-images/custom-transport-paused-large.png#lightbox)
+![Screenshot of a MediaElement with playback paused, on iOS and Android.](mediaelement-images/custom-transport-paused-large.png#lightbox)
 
 Pressing the **Stop** button stops playback and returns the position of the media file to the beginning.
 


### PR DESCRIPTION
## Fixes # <!-- Link to a relevant issue # in this docs repository (if any, otherwise remove this line) -->
- [Fixed Screenshot image link of a MediaElement playing a video, on iOS and Android.](https://learn.microsoft.com/en-us/xamarin/community-toolkit/views/mediaelement-images/playback-controls-large.png#lightbox)
- [Fixed Screenshot image link of a MediaElement with custom transport controls, on iOS and Android.](https://learn.microsoft.com/en-us/xamarin/community-toolkit/views/mediaelement-images/custom-transport-playback-large.png#lightbox)
- [Fixed Screenshot image link of a MediaElement with playback paused, on iOS and Android.](https://learn.microsoft.com/en-us/xamarin/community-toolkit/views/mediaelement-images/custom-transport-paused-large.png#lightbox)
## Docs for Toolkit PR [#](https://github.com/xamarin/XamarinCommunityToolkit/pull/#) <!-- Link to relevant issue or Feature PR # of the Xamarin community toolkit repo which will create a reference to the associated issue and PR once it is created, remove if not tied to an issue or feature -->

## What changes to the docs does this PR provide?

The Community Toolkit MediaElement Article (documentation) image links are broken,
The pr fixes the links using relative paths.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/.template.md).
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/TOC.yml).
- [x] Ran against a spell and grammar checker.
- [x] Contains **NO** breaking changes.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information