### PR TITLE
Wrong converter name in links

### DIFF
--- a/docs/converters/enumtoboolconverter.md
+++ b/docs/converters/enumtoboolconverter.md
@@ -54,12 +54,9 @@ The EnumToBoolConverter is a converter that allows users to convert a `Enum` val
 
 ## Sample
 
-> [!NOTE]
-> Currently there's no sample available for this feature yet. Want to add one? We are open to [community contributions](https://github.com/xamarin/XamarinCommunityToolkit).
+[EnumToBoolConverter sample page source](https://github.com/CommunityToolkit/Maui/blob/main/samples/CommunityToolkit.Maui.Sample/Pages/Converters/EnumToBoolConverterPage.xaml)
 
-<!-- [EnumToBoolConverter sample page Source](https://github.com/xamarin/XamarinCommunityToolkit)
-
-You can see this in action in the [Xamarin Community Toolkit Sample App](https://github.com/xamarin/XamarinCommunityToolkit). -->
+You can see this in action in the [Xamarin Community Toolkit Sample App](https://github.com/xamarin/XamarinCommunityToolkit).
 
 ## API
 

--- a/docs/converters/enumtoboolconverter.md
+++ b/docs/converters/enumtoboolconverter.md
@@ -57,10 +57,10 @@ The EnumToBoolConverter is a converter that allows users to convert a `Enum` val
 > [!NOTE]
 > Currently there's no sample available for this feature yet. Want to add one? We are open to [community contributions](https://github.com/xamarin/XamarinCommunityToolkit).
 
-<!-- [IndexToArrayItemConverter sample page Source](https://github.com/xamarin/XamarinCommunityToolkit)
+<!-- [EnumToBoolConverter sample page Source](https://github.com/xamarin/XamarinCommunityToolkit)
 
 You can see this in action in the [Xamarin Community Toolkit Sample App](https://github.com/xamarin/XamarinCommunityToolkit). -->
 
 ## API
 
-* [IndexToArrayItemConverter source code](https://github.com/xamarin/XamarinCommunityToolkit/blob/main/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/EnumToBoolConverter.shared.cs)
+* [EnumToBoolConverter source code](https://github.com/xamarin/XamarinCommunityToolkit/blob/main/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/EnumToBoolConverter.shared.cs)


### PR DESCRIPTION
## Docs for Toolkit PR [#](https://github.com/xamarin/XamarinCommunityToolkit/pull/#) <!-- Link to relevant issue or Feature PR # of the Xamarin community toolkit repo which will create a reference to the associated issue and PR once it is created, remove if not tied to an issue or feature -->

## What changes to the docs does this PR provide?

IndexToArrayItemConverter name was incorrectly used on EnumToBoolConverter docs page.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/.template.md).
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/TOC.yml).
- [x] Ran against a spell and grammar checker.
- [x] Contains **NO** breaking changes.

## Other information
